### PR TITLE
Performance/service tracking

### DIFF
--- a/Source/Core/ServicePassthroughDelegate.swift
+++ b/Source/Core/ServicePassthroughDelegate.swift
@@ -14,7 +14,7 @@ public protocol ServicePassthroughDelegate: class {
     func requestSent(request: NSURLRequest)
     
     /// Called after a NSURLSessionDataTask has completed
-    func responseReceived(response: NSURLResponse?, data: NSData?, error: NSError?)
+    func responseReceived(response: NSURLResponse?, data: NSData?, request: NSURLRequest?, error: NSError?)
     
     /// Called before an updateUI handler is invoked
     func updateUIBegin(response: NSURLResponse?)

--- a/Source/Core/WebService.swift
+++ b/Source/Core/WebService.swift
@@ -166,7 +166,7 @@ extension WebService: SessionDataTaskDataSource {
         passthroughDelegate?.requestSent(request)
         
         return serviceDataTaskSource.dataTaskWithRequest(request) { data, response, error in
-            self.passthroughDelegate?.responseReceived(response, data: data, error: error)
+            self.passthroughDelegate?.responseReceived(response, data: data, request: request, error: error)
             completionHandler(data, response, error)
         }
     }


### PR DESCRIPTION
Pulled in Electrode's modifiedRequest protocol. Extended passThroughDelegate to take a request? on the response callback